### PR TITLE
Refactor: OrderResponse 간소화, 주문 내역 시간 null 값 표기 수정

### DIFF
--- a/back/src/main/java/com/back/domain/order/order/dto/reponse/OrderResponse.java
+++ b/back/src/main/java/com/back/domain/order/order/dto/reponse/OrderResponse.java
@@ -1,25 +1,25 @@
 package com.back.domain.order.order.dto.reponse;
 
 import com.back.domain.order.order.entity.Order;
+import com.back.domain.order.orderItem.dto.OrderItemResponse;
+import jakarta.persistence.PrePersist;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class OrderResponse {
     int id;
     LocalDateTime createDate;
-    String email;
-    String address;
-    String postcode;
+    private final List<OrderItemResponse> items;
 
     public OrderResponse(Order order) {
         this.id = order.getId();
         this.createDate = order.getCreateDate();
-        this.email = order.getEmail();
-        this.address = order.getAddress();
-        this.postcode = order.getPostcode();
+        this.items = order.getOrderItems().stream()
+                .map(OrderItemResponse::from)
+                .toList();
     }
-
-
 }
+

--- a/back/src/main/java/com/back/domain/order/order/entity/Order.java
+++ b/back/src/main/java/com/back/domain/order/order/entity/Order.java
@@ -4,9 +4,11 @@ import com.back.domain.order.orderItem.entity.OrderItem;
 import com.back.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,8 +26,14 @@ public class Order extends BaseEntity {
     private String email;
     private String address;
     private String postcode;
+    private LocalDateTime createDate;
 
     @OneToMany(mappedBy = "order", fetch = LAZY, cascade = ALL, orphanRemoval = true)
     @Builder.Default
     private List<OrderItem> orderItems = new ArrayList<>();
+
+    @PrePersist
+    public void prePersist() {
+        this.createDate = LocalDateTime.now();
+    }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
OrderResponse 간소화 필요한 것만 남겼습니다. 
상세한 것은 OrderDetailResponse 이곳에 다 들어 있어 역할이 겹치기 때문에 바꾸었습니다.

백엔드에서 테스트 데이터 생성 후 http://localhost:8080/api/v1/orders?email= 로 테스트 해보면
정상적으로 시간이 표기되지만 프론트로 테스트할 경우 시간 전달이 제대로 되지 않아 null값으로 표기되는 부분을 수정하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
OrderResponse 간소화
프론트에서 시간 부분 null값으로 표기되는 부분 수정

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
